### PR TITLE
Fix dependency with marked

### DIFF
--- a/card-simple.js
+++ b/card-simple.js
@@ -1,0 +1,80 @@
+'use strict';
+/**
+ * card tag
+ * Only basic functionality.
+ * Syntax:
+ *   {% card [header] [title=title] [subtitle=] [img=src] [imgalt=alt] [col=12,sm-1,lg-3]%}
+ *   content
+ *   {% endcard %}
+ */
+
+
+
+function replaceAll(str, find, replace) {
+    return str.replace(new RegExp(find.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1"), 'g'), replace);
+}
+module.exports = function(ctx) {
+  return function cardTag(args, content) {
+	var header, subtitle, title, img, imgAlt;
+	var col;
+	var i,j;
+	
+	for(i = 0; i < args.length; i++) {
+		var idx = args[i].indexOf("=");
+		if(idx == -1) {
+			if(args[i] === "col") {
+				col = "col";
+			}
+			else
+				header = args[i];
+			continue;
+		}
+		
+		switch(args[i].substring(0, idx).toLowerCase()) {
+			case "col": 
+				col = "";
+				var param = args[i].substring(idx+1).split(",");
+				for(j = 0; j < param.length; j++) {
+					col+=" col-" + param[j];
+				}
+				if(param.length == 0) {
+					col = "col";
+				}
+				break;
+			case "title": title = args[i].substring(idx+1); break;
+			case "subtitle": subtitle = args[i].substring(idx+1); break;
+			case "img": img = args[i].substring(idx+1); break;
+			case "imgalt": imgAlt = args[i].substring(idx+1); break;
+			default:
+				header = args[i];
+				break;
+		}
+	}
+	
+	
+	content = ctx.render.renderSync({text: content, engine: 'markdown'}, { 
+		breaks: true,
+		smartLists: false
+	});
+	// clean up some "bad" end-of card rendering
+	if(content.lastIndexOf('<div class="card-body">') !== -1)
+		content = content.substring(0, content.length - 34);
+	else
+		content += "</div>";
+	content = replaceAll(content, "</p><br>", "</p>");
+	
+	var card = '<div class="card">' + 
+		(header?'<div class="card-header">' + header + '</div>':'') + 
+		(img?('<img class="card-img-top" src="' + img + '"'+(imgAlt?(' alt="'+imgAlt+'"'):'')+'/>'):'') + 
+		'<div class="card-body">'+ 
+			(title?'<h4 class="card-title">' + title + '</h4>':'') + 
+			(subtitle?'<h6 class="card-subtitle mb-2 text-mited">' + subtitle + '</h6>':'') + 
+			content + 
+		'</div>';	
+
+	if(col) {
+		return '<div class="' + col + '">' + card + '</div>';
+	} else
+		return card;
+	};
+};

--- a/card.js
+++ b/card.js
@@ -88,7 +88,7 @@ module.exports = function(ctx) {
 		smartLists: false
 	});
 	// clean up some "bad" end-of card rendering
-	if(content.lastIndexOf('<div class="card-body">'))
+	if(content.lastIndexOf('<div class="card-body">') !== -1)
 		content = content.substring(0, content.length - 34);
 	else
 		content += "</div>";

--- a/carousel-simple.js
+++ b/carousel-simple.js
@@ -1,0 +1,119 @@
+'use strict';
+/**
+ * carousel tag
+ *
+ * Syntax:
+ *   {% carousel [col=12,sm-1,lg-3] nav indicators %}
+ *     {img "path/to/img"}
+ *     # First slide
+ *     This is a text
+ *     {img "path/to/img"}
+ *     # Second slide
+ *     This is a text
+ *   }
+ *   {% endcarousel %}
+ */
+
+
+function replaceAll(str, find, replace) {
+    return str.replace(new RegExp(find.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1"), 'g'), replace);
+}
+
+module.exports = function(ctx) {
+  return function carouselTag(args, content) {
+	var nav = false, indicators = false;
+	var col;
+	var i,j;
+	
+	for(i = 0; i < args.length; i++) {
+		var idx = args[i].indexOf("=");
+		if(idx == -1) {
+			switch(args[i]) {
+				case "col": col = "col"; break;
+				case "controls":
+				case "nav": nav = true; break;
+				case "indicators": 
+				case "lines": indicators = true; break;
+			}
+			continue;
+		}
+		
+		switch(args[i].substring(0, idx).toLowerCase()) {
+			case "col": 
+				col = "";
+				var param = args[i].substring(idx+1).split(",");
+				for(j = 0; j < param.length; j++) {
+					col+=" col-" + param[j];
+				}
+				if(param.length == 0) {
+					col = "col";
+				}
+				break;
+		}
+	}
+	
+	
+	content = ctx.render.renderSync({text: content, engine: 'markdown'}, { 
+		breaks: true,
+		smartLists: false
+	});
+	
+	// splut the content at each img
+	var imgBlock = [];
+	
+	content.split("<img").forEach(function(ct) {
+		ct = replaceAll(ct, "<p></p>", "");
+		// ignore empty block
+		if(ct.indexOf("src=") == -1 || ct.length < 10) {
+			return;
+		}
+		
+		// split apart the img and the content
+		var endImg = ct.indexOf(">");
+		var rest = ct.substring(endImg+1);
+		
+		if(rest.length <= 5) {
+			rest = '';
+		} else {
+			rest = '<div class="carousel-caption d-none d-md-block">' + rest + '</div>';
+		}
+		
+		imgBlock.push(
+			"<img" + ct.substring(0, endImg+1)
+			+ rest
+		);
+	});
+	
+	
+	var cid = "car_" + Math.round(Math.random() * 10000) + "_" + content.length;
+	var card = '<div class="carousel slide" id="'+cid+'" data-ride="carousel">';
+	if(indicators) {
+		card += '\n<ol class="carousel-indicators">';
+		for(var i = 0; i < imgBlock.length; i++) {
+			card += '<li data-target="#'+cid+'" '+(i==0?'class="active"':'')+' data-slide-to="'+i+'"></li>';
+		}
+		card += '</ol>\n';
+	}
+	
+	var first = true;
+	imgBlock.forEach(function(block) {
+		card += '<div class="carousel-item'+(first?' active':'')+'">';
+		card += block;
+		card += '</div>';
+		first = false;
+	});
+	
+	// add controls
+	if(nav) {
+		card += '\n<a class="carousel-control-prev" href="#'+cid+'" role="button" data-slide="prev"><span class="carousel-control-prev-icon" aria-hidden="true"></span><span class="sr-only">Previous</span></a>';
+		card += '<a class="carousel-control-next" href="#'+cid+'" role="button" data-slide="next"><span class="carousel-control-next-icon" aria-hidden="true"></span><span class="sr-only">Next</span></a>\n';
+	}
+	
+	card +='</div>';	
+
+	if(col) {
+		return '<div class="' + col + '">' + card + '</div>';
+	} else
+		return card;
+	};
+};

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var ctx = hexo;
 var tag = ctx.extend.tag;
 
+
 tag.register('label', require('./label'));
 tag.register('badge', require('./badge'));
 tag.register('btn', require('./btn'));
@@ -11,8 +12,19 @@ tag.register('pill', require('./pill'));
 tag.register('row', require('./row')(ctx), true);
 tag.register('col', require('./col')(ctx), true);
 tag.register('alert', require('./alert')(ctx), true);
-tag.register('card', require('./card')(ctx), true);
-tag.register('carousel', require('./carousel')(ctx), true);
 tag.register('jumbo', require('./jumbo')(ctx), true);
 tag.register('jumbotron', require('./jumbo')(ctx), true);
 tag.register('textcolor', require('./textcolor')(ctx), true);
+
+// load modules requiring marked
+try {
+	// try to resolve marked to load the advanced card and carousel
+	require.resolve("marked");
+	tag.register('card', require('./card')(ctx), true);
+	tag.register('carousel', require('./carousel')(ctx), true);
+} catch(ex) {
+	// marked not available
+		tag.register('card', require('./card-simple')(ctx), true);
+		tag.register('carousel', require('./carousel-simple')(ctx), true);
+}
+


### PR DESCRIPTION
I fixed a small bug and adjusted the module loading to check for marked before continueing. 

I will take a look at markdown-it and try to get card and carousel working with them as well.

It would be easier if there would be some other way to postprocess or adjust the output of the renderer to allow for more complex tags with content (i.e. the way the carousel handles image tags or to filter out headings and create a different html for them).

I tested it with marked disabled and it it renders fine - except for card and carousel